### PR TITLE
Update URL to avoid ATS error

### DIFF
--- a/Chapter 28 - WebServices/RanchForecast/RanchForecast/ScheduleFetcher.swift
+++ b/Chapter 28 - WebServices/RanchForecast/RanchForecast/ScheduleFetcher.swift
@@ -35,7 +35,7 @@ class ScheduleFetcher {
     
     
     func fetchCoursesUsingCompletionHandler(completionHandler: FetchCoursesResult -> Void) {
-        let url = NSURL(string: "http://bookapi.bignerdranch.com/courses.json")!
+        let url = NSURL(string: "https://bookapi.bignerdranch.com/courses.json")!
         let request = NSURLRequest(URL: url)
         
         let task = session.dataTaskWithRequest(request) { data, response, error in


### PR DESCRIPTION
With Xcode 7, you will receive an ATS error due to the non-https URL:  "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection."
